### PR TITLE
fix: set claude-code container tag to latest

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -54,5 +54,5 @@ jobs:
         with:
           context: ./docker/coding_agents/claude_code
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: latest
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Change claude-code container tags from dynamic metadata output to fixed 'latest' tag
- Simplifies the tagging strategy for the container image

## Test plan
- [x] Verify GitHub Actions workflow passes
- [x] Confirm container is built with 'latest' tag

🤖 Generated with [Claude Code](https://claude.ai/code)