### PR TITLE
fix: correct Docker image tag format in Claude Code workflow

### DIFF
--- a/.github/workflows/build-claude-code.yml
+++ b/.github/workflows/build-claude-code.yml
@@ -54,5 +54,4 @@ jobs:
         with:
           context: ./docker/coding_agents/claude_code
           push: ${{ github.event_name != 'pull_request' }}
-          tags: latest
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest


### PR DESCRIPTION
## Summary
- Update Docker image tag to include full registry path
- Remove reference to undefined metadata labels output
- Ensures proper image naming for GitHub Container Registry

## Changes
- Changed tag from `latest` to `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest`
- Removed `labels: ${{ steps.meta.outputs.labels }}` since metadata extraction is commented out

## Test plan
- [x] Verify GitHub Actions workflow passes
- [x] Confirm Docker image is pushed to `ghcr.io/hakuturu583/naruto/claude-code:latest`

🤖 Generated with [Claude Code](https://claude.ai/code)